### PR TITLE
Move to newer API version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<img src="./docs/src/assets/logo.svg" width="350" height="200"></img>
 # CancerImagingArchive.jl
 
 <!--
@@ -15,7 +16,7 @@ A Julia interface for [The Cancer Imaging Archive (TCIA) REST-API](https://wiki.
 The package can be installed by
 
 ```julia
-julia> ]add https://github.com/notZaki/CancerImagingArchive.jl.git
+julia> ]add CancerImagingArchive
 ```
 
 The [documentation pages](https://notZaki.github.io/CancerImagingArchive.jl/dev) provide details/examples of how to use the package.

--- a/docs/src/guide/downloading.md
+++ b/docs/src/guide/downloading.md
@@ -37,12 +37,8 @@ Continuing from the previous example, if we only wanted to download the first im
 
 ```@repl ex
 series_sops = sop(series = chosen_series)
-chosen_sop = series_sops.sop_instance_uid[1]
+chosen_sop = series_sops.SOPInstanceUID[1]
 ```
-
-!!! note
-
-    The `sop()` function returns a column named `sop_instance_uid` instead of `SOPInstanceUID`.
 
 ### Downloading the single image
 

--- a/docs/src/guide/queries.md
+++ b/docs/src/guide/queries.md
@@ -32,7 +32,7 @@ The imaging modalities in a specific collection and/or anatomy are listed by:
 ```@repl ex
 modalities(collection = "TCGA-KIRP")
 modalities(bodypart = "BRAIN")
-modalities(collection = "TCGA-GBM", bodypart = "BRAIN")
+modalities(collection = "CPTAC-HNSCC", bodypart = "HEAD")
 ```
 
 !!! note
@@ -43,7 +43,7 @@ modalities(collection = "TCGA-GBM", bodypart = "BRAIN")
 
 The anatomy scanned in a specific collection and/or modality are listed by:
 ```@repl ex
-bodyparts(collection = "TCGA-GBM")
+bodyparts(collection = "CPTAC-HNSCC")
 bodyparts(modality = "CT")
 bodyparts(collection = "Soft-tissue-Sarcoma", modality = "MR")
 ```
@@ -83,12 +83,8 @@ patients_by_modality(collection = "TCGA-SARC", modality = "MR")
 In large collections, it can be useful to query patients that were added after a date specified as YYYY-MM-DD.
 This is accomplished by:
 ```@repl ex
-newpatients(collection = "TCGA-GBM", date = "2012-01-01")
+newpatients(collection = "TCGA-GBM", date = "2015-01-01")
 ```
-
-!!! warning
-
-    The `newpatients()` function currently does not work and I don't know why.
 
 ## Patient studies
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,9 +4,9 @@ The `CancerImagingArchive.jl` module provides a Julia interface for exploring an
 
 ## Installation
 
-This module is not currently registered in Julia's general registry but it can be still be installed by
+This module can be installed by:
 ```julia
-julia> ]add https://github.com/notZaki/CancerImagingArchive.jl.git
+julia> ]add CancerImagingArchive
 ```
 Once installed, the package can be loaded via
 ```julia

--- a/src/CancerImagingArchive.jl
+++ b/src/CancerImagingArchive.jl
@@ -7,7 +7,8 @@ export patients, patients_by_modality, newpatients, newstudies, sop
 export single_image, images
 export dataframe_to_csv, dictionary_to_json
 
-const _host = "services.cancerimagingarchive.net/services/v3/TCIA/query"
+# const _host = "services.cancerimagingarchive.net/services/v3/TCIA/query"
+const _host = "api.cancerimagingarchive.net/radiology"
 const _format = "csv"
 const _q = Dict(
     :collection => "Collection",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,7 +34,7 @@ using Test
 
     single_sop = sop(series = series_ids[1])
     test_dicom = joinpath(@__DIR__, "test.dcm")
-    single_image(series = series_ids[1], sop = single_sop.sop_instance_uid[1], file=test_dicom)
+    single_image(series = series_ids[1], sop = single_sop.SOPInstanceUID[1], file=test_dicom)
     @test isfile(test_dicom)
     @test filesize(test_dicom) == 38100
 
@@ -50,5 +50,5 @@ using Test
     @test dictionary_to_json(dictionary = patients_OT, file = "test.json") == nothing
 
     ## Broken for some reason
-    # newpatients(collection="TCGA-GBM", date="1940-01-01")
+    @test length(newpatients(collection="TCGA-GBM", date="1940-01-01", format = "json")) > 1
 end


### PR DESCRIPTION
This solves two issues:
- `sop()` now returns `SOPInstanceUID` instead of `sop_instance_uid`
- `newpatients()` now works

Also changed installation instructions. They won't work for now, but should hopefully work once package is registered.