### PR TITLE
Refactor tests. Add note about csv/json type differences.

### DIFF
--- a/docs/src/guide/formats.md
+++ b/docs/src/guide/formats.md
@@ -79,3 +79,21 @@ dictionary_to_json(dictionary = studies_array, file = "output_file.json")
 rm("output_file.csv")
 rm("output_file.json")
 ```
+
+## Note on types
+
+The DataFrames object tries to figure out the types from the input while the DictionaryArray just accepts whatever the API returns.
+For a practical example of this, suppose we want to know the size of an imaging series; the DataFrame version will be
+```@example ex
+series_size(series = "1.3.6.1.4.1.14519.5.2.1.4591.4001.241972527061347495484079664948")
+```
+while the JSON version will be
+```@repl ex
+series_size(series = "1.3.6.1.4.1.14519.5.2.1.4591.4001.241972527061347495484079664948", format="json")[1]
+```
+The difference between the two is that the DataFrames version recognizes that `TotalSizeInBytes` is a number whereas the DictionaryArray displays it as a string (because the API returns it as a string).
+
+DataFrames' ability to recognize types is usually helpful, but sometimes it can fail.
+For example, in an anonymized dataset where patient names are replaced by numbers, the DataFrames object will incorrectly treat the names as numbers.
+
+These differences are unlikely to cause problems in practice so it isn't something to be actively concerned about.

--- a/docs/src/guide/queries.md
+++ b/docs/src/guide/queries.md
@@ -121,11 +121,15 @@ That's because the query returns the SeriesInstanceUID which is needed to downlo
 
 !!! note
 
-    Although the above example only shows the SeriesInstanceUID, the output actually contains more information which is not shown because there isn't enough screen space. This is why the top of each output states that it is a `Nx15 DataFrames` object where 14 columns are not being printed. The entire table could be printed by:
+    Although the above example only shows the SeriesInstanceUID, the output actually contains more information which is not shown because there isn't enough screen space. This is why the top of each output states that it is a `Nx16 DataFrames` object where 15 columns are not being printed. The entire table could be printed by:
     ```julia
     series_dataframe = series(patient = "TCGA-QQ-A8VF");
     show(series_dataframe, allrows = true, allcols = true)
     ```
+
+!!! warning
+
+    Passing `format = "json"` will result in one fewer column. This is because the `AnnotationsFlag` field is returned for CSV output but not for JSON. 
 
 ### Imaging series size
 
@@ -133,6 +137,10 @@ The size (in bytes) and number of images for a given imaging series is given by
 ```@repl ex
 series_size(series = "1.3.6.1.4.1.14519.5.2.1.4591.4001.241972527061347495484079664948")
 ```
+
+!!! warning
+
+    It is recommended that `series_size()` should **not** be used with `format = json`. This is because the json version interprets the `TotalSizeInBytes` as string/text rather than a number.
 
 ## Service-Object Pairs (SOP)
 

--- a/src/CancerImagingArchive.jl
+++ b/src/CancerImagingArchive.jl
@@ -267,7 +267,7 @@ has_format(query, format) = haskey(query, "format") && query["format"]==format
 
 function _request_csv(url)
     r = HTTP.request("GET", url)
-    return CSV.read(r.body)
+    return CSV.read(r.body, copycols=true)
 end
 
 function _request_json(url)


### PR DESCRIPTION
- Old tests were one big test-set. Updated version has smaller test-sets.
- New tests revealed some differences between CSV and JSON results, so a few notes were added to documentations. These differences are:
    + `series()` returns an `AnnotationsFlag` for CSV, but not for JSON
         + Somewhat related: Version3 of the API did not return PatientIDs for `series()`, but the newer version does.
    + `series_size()` returns `TotalSizeInBytes` as a string for JSON. The CSV version gets interpreted as a number/float.
    + Empty values get treated as `missing` in CSV version, while JSON leaves it as empty
         + This made it somewhat difficult to compare CSV and JSON in tests because `missing =/= empty`