### PR TITLE
Add convenience function for downloading images

### DIFF
--- a/docs/src/guide/downloading.md
+++ b/docs/src/guide/downloading.md
@@ -27,6 +27,34 @@ zip_file = "output_file.zip"; # Can also be a path
 tcia_images(series = chosen_series, file = zip_file)
 ```
 
+### Convenience wrapper
+
+The above steps will only download a zip file which then has to be extracted. 
+This can be cumbersome when downloading multipled series, so the `download_series()` function is provided for convenience.
+
+!!! note
+
+    The `download_series()` assumes that the `unzip` utility is installed on the system. This can be verified by typing `unzip` in a terminal or `;unzip` in julia.
+    ```
+
+**Downloading a single series**
+
+The following will download and extract the `chosen_series` (selected above) and extract the images in the current directory `./`.
+```julia
+julia> download_series(chosen_series, "./")
+```
+
+Multiple series can be downloaded as well from a Dataframe by
+```julia
+julia> series = tcia_series(collection = "AAPM-RT-MAC", patient = "RTMAC-LIVE-001")
+julia> download_series(series, "./testdf")
+```
+or from an array of dictionaries by
+```julia
+julia> seriesjs = tcia_series(collection = "AAPM-RT-MAC", patient = "RTMAC-LIVE-001", format="json") 
+julia> download_series(seriesjs, "./testjs")
+```
+
 ## Single image
 
 ### Selecting the single image

--- a/docs/src/guide/downloading.md
+++ b/docs/src/guide/downloading.md
@@ -44,7 +44,9 @@ The following will download and extract the `chosen_series` (selected above) and
 julia> download_series(chosen_series, "./")
 ```
 
-Multiple series can be downloaded as well from a Dataframe by
+**Downloading multiple series**
+
+The wrapper function can download multiple series from a Dataframe by
 ```julia
 julia> series = tcia_series(collection = "AAPM-RT-MAC", patient = "RTMAC-LIVE-001")
 julia> download_series(series, "./testdf")

--- a/src/CancerImagingArchive.jl
+++ b/src/CancerImagingArchive.jl
@@ -2,6 +2,9 @@ module CancerImagingArchive
 
 using HTTP, CSV, DataFrames, JSON
 
+include("download_series.jl")
+export download_series
+
 export tcia_collections, tcia_modalities, tcia_bodyparts, tcia_manufacturers, tcia_studies, tcia_series, tcia_series_size
 export tcia_patients, tcia_patients_by_modality, tcia_newpatients, tcia_newstudies, tcia_sop
 export tcia_single_image, tcia_images

--- a/src/download_series.jl
+++ b/src/download_series.jl
@@ -1,0 +1,43 @@
+function _initialize_destination(destination, overwrite)
+    if overwrite
+        rm(destination; force = true, recursive = true)
+    end
+    if !isdir(destination)
+        mkpath(destination)
+    end
+    return destination
+end
+
+function download_series(series_id::AbstractString, destination = "./", overwrite = true)
+    _initialize_destination(destination, overwrite)
+    zip_file = joinpath(destination, "downloaded.zip")
+    tcia_images(series = series_id, file = zip_file)
+    unzip_command = `unzip -o $zip_file -d $destination`
+    run(unzip_command)
+    rm(zip_file)
+    return destination
+end
+
+function download_series(series_df::DataFrames.DataFrame, destination = "./"; append_desc = true, overwrite = true)
+    return [download_series(row, destination; append_desc=append_desc, overwrite=overwrite) for row in eachrow(series_df)]
+end
+
+function download_series(series::DataFrames.DataFrameRow, destination = "./"; append_desc = true, overwrite = true)
+    series_id = series.SeriesInstanceUID
+    if append_desc 
+        destination = joinpath(destination, series.SeriesDescription)
+    end
+    return download_series(series_id, destination, overwrite)
+end
+
+function download_series(series::Dict, destination = "./"; append_desc = true, overwrite = true)
+    series_id = series["SeriesInstanceUID"]
+    if append_desc 
+        destination = joinpath(destination, series["SeriesDescription"])
+    end
+    return download_series(series_id, destination, overwrite)
+end
+
+function download_series(series_array::Array, destination = "./"; append_desc = true, overwrite = true)
+    return [download_series(series, destination; append_desc=append_desc, overwrite=overwrite) for series in series_array]
+end

--- a/src/download_series.jl
+++ b/src/download_series.jl
@@ -8,11 +8,17 @@ function _initialize_destination(destination, overwrite)
     return destination
 end
 
-function _append_to_path(destination, append)
-  append = replace(append, r"[^0-9a-zA-Z]" => "")
-  return joinpath(destination, append)
+function _append_to_path(path, thing_to_append)
+  thing_to_append = replace(thing_to_append, r"[^0-9a-zA-Z]" => "")
+  return joinpath(path, thing_to_append)
 end
 
+"""
+    download_series(series_id::AbstractString, destination::AbstractString = "./", overwrite::Boolean = true)
+
+Downloads images belonging to series with `series_id` and extracts them to `destination` folder.
+If the destination folder already exists, then it will be overwritten by default unless `overwrite = false`.
+"""
 function download_series(series_id::AbstractString, destination = "./", overwrite = true)
     _initialize_destination(destination, overwrite)
     zip_file = joinpath(destination, "downloaded.zip")
@@ -23,6 +29,14 @@ function download_series(series_id::AbstractString, destination = "./", overwrit
     return destination
 end
 
+"""
+    download_series(df::DataFrame, destination::AbstractString = "./"; append_desc::Boolean = true, overwrite::Boolean = true)
+
+Downloads all images from the series in the dataframe `df` and then extracts them to `destination` folder. 
+The `df` can be obtained through the `tcia_series()` function.
+By default, the series description will be appended to the path unless `append_desc = false`.
+If the destination folder already exists, then it will be overwritten by default unless `overwrite = false`.
+"""
 function download_series(series_df::DataFrames.DataFrame, destination = "./"; append_desc = true, overwrite = true)
     return [download_series(row, destination; append_desc=append_desc, overwrite=overwrite) for row in eachrow(series_df)]
 end
@@ -35,14 +49,23 @@ function download_series(series::DataFrames.DataFrameRow, destination = "./"; ap
     return download_series(series_id, destination, overwrite)
 end
 
+
+"""
+    download_series(arr::Array, destination::AbstractString = "./"; append_desc::Boolean = true, overwrite::Boolean = true)
+
+Downloads all images from the series in the array `arr` and then extracts them to `destination` folder.
+The `arr` can be obtained through the `tcia_series(..., format = "json")` command.
+By default, the series description will be appended to the path unless `append_desc = false`.
+If the destination folder already exists, then it will be overwritten by default unless `overwrite = false`.
+"""
+function download_series(series_array::Array, destination = "./"; append_desc = true, overwrite = true)
+    return [download_series(series, destination; append_desc=append_desc, overwrite=overwrite) for series in series_array]
+end
+
 function download_series(series::Dict, destination = "./"; append_desc = true, overwrite = true)
     series_id = series["SeriesInstanceUID"]
     if append_desc 
         destination = _append_to_path(destination, series["SeriesDescription"])
     end
     return download_series(series_id, destination, overwrite)
-end
-
-function download_series(series_array::Array, destination = "./"; append_desc = true, overwrite = true)
-    return [download_series(series, destination; append_desc=append_desc, overwrite=overwrite) for series in series_array]
 end

--- a/src/download_series.jl
+++ b/src/download_series.jl
@@ -8,6 +8,11 @@ function _initialize_destination(destination, overwrite)
     return destination
 end
 
+function _append_to_path(destination, append)
+  append = replace(append, r"[^0-9a-zA-Z]" => "")
+  return joinpath(destination, append)
+end
+
 function download_series(series_id::AbstractString, destination = "./", overwrite = true)
     _initialize_destination(destination, overwrite)
     zip_file = joinpath(destination, "downloaded.zip")
@@ -25,7 +30,7 @@ end
 function download_series(series::DataFrames.DataFrameRow, destination = "./"; append_desc = true, overwrite = true)
     series_id = series.SeriesInstanceUID
     if append_desc 
-        destination = joinpath(destination, series.SeriesDescription)
+        destination = _append_to_path(destination, series.SeriesDescription)
     end
     return download_series(series_id, destination, overwrite)
 end
@@ -33,7 +38,7 @@ end
 function download_series(series::Dict, destination = "./"; append_desc = true, overwrite = true)
     series_id = series["SeriesInstanceUID"]
     if append_desc 
-        destination = joinpath(destination, series["SeriesDescription"])
+        destination = _append_to_path(destination, series["SeriesDescription"])
     end
     return download_series(series_id, destination, overwrite)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -173,6 +173,15 @@ end
     @test filesize(dicom_file) == 980794
 end
 
+@testset "Download series" begin
+  series = tcia_series(collection = "AAPM-RT-MAC", patient = "RTMAC-LIVE-001")
+  seriesjs = tcia_series(collection = "AAPM-RT-MAC", patient = "RTMAC-LIVE-001", format="json") 
+  download_series(series, "./testdf")
+  download_series(seriesjs, "./testjs")
+  download_series(series, "./testdf"; overwrite = false)
+end
+
+
 @testset "Utilities - remove_empty!()" begin
     dict_potentialy_empty_values = Dict(1 => "", 2 => "hello", 3 => "b", 4 => "", 5 => "ye")
     CancerImagingArchive.remove_empty!(dict_potentialy_empty_values)


### PR DESCRIPTION
The steps needed to download were a bit cumbersome because `tcia_images()` downloads one zip file at a time which then has to be extracted.

The `download_series()` function has been added and it can download multiple series if they are in an appropriate dataframe or dictionary-array. It also unzips the downloaded files.